### PR TITLE
[feature]: New ways to sort the table

### DIFF
--- a/__tests__/SearchSort.test.tsx
+++ b/__tests__/SearchSort.test.tsx
@@ -1,0 +1,128 @@
+// Necessary imports
+import React from "react";
+import { render, waitFor, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import SearchSort from "../components/SearchSort";
+
+describe("<SearchSort />", () => {
+  it("sets the selected SE method correctly", () => {
+    // Mock functions for props
+    const setSelectedSEMethod = jest.fn();
+    const mockSetSearchTerm = jest.fn();
+    const mockSetStartYear = jest.fn();
+    const mockSetEndYear = jest.fn();
+    const mockSetSortPreference = jest.fn();
+
+    // Render component
+    const { getByDisplayValue, getByText } = render(
+      <SearchSort
+        searchTerm=""
+        setSearchTerm={mockSetSearchTerm}
+        allSEMethods={["Method 1", "Method 2", "A Specific SE Method"]}
+        selectedSEMethod="Method 1"
+        setSelectedSEMethod={setSelectedSEMethod}
+        startYear={null}
+        setStartYear={mockSetStartYear}
+        endYear={null}
+        setEndYear={mockSetEndYear}
+        sortPreference={null}
+        setSortPreference={mockSetSortPreference}
+      />
+    );
+
+    // Interact with the dropdown
+    const dropdown = getByDisplayValue("Method 1");
+    fireEvent.change(dropdown, { target: { value: "A Specific SE Method" } });
+
+    // Assert
+    expect(setSelectedSEMethod).toHaveBeenCalledWith("A Specific SE Method");
+  });
+
+  it("sets the start and end year correctly", () => {
+    // Mock functions for props
+    const setSelectedSEMethod = jest.fn();
+    const mockSetSearchTerm = jest.fn();
+    const mockSetStartYear = jest.fn();
+    const mockSetEndYear = jest.fn();
+    const mockSetSortPreference = jest.fn();
+
+    // Render component
+    const { getByPlaceholderText } = render(
+      <SearchSort
+        searchTerm=""
+        setSearchTerm={mockSetSearchTerm}
+        allSEMethods={["Method 1", "Method 2", "A Specific SE Method"]}
+        selectedSEMethod="Method 1"
+        setSelectedSEMethod={setSelectedSEMethod}
+        startYear={null}
+        setStartYear={mockSetStartYear}
+        endYear={null}
+        setEndYear={mockSetEndYear}
+        sortPreference={null}
+        setSortPreference={mockSetSortPreference}
+      />
+    );
+
+    // Interact with the "From Year" input
+    const startYearInput = getByPlaceholderText("From Year");
+    fireEvent.change(startYearInput, { target: { value: "2005" } });
+
+    // Assert
+    expect(mockSetStartYear).toHaveBeenCalledWith(2005);
+
+    // Interact with the "To Year" input
+    const endYearInput = getByPlaceholderText("To Year");
+    fireEvent.change(endYearInput, { target: { value: "2015" } });
+
+    // Assert
+    expect(mockSetEndYear).toHaveBeenCalledWith(2015);
+  });
+
+  it("handles SE method selection and sort preference correctly", () => {
+    // Mock functions for props
+    const mockSetSearchTerm = jest.fn();
+    const mockSetSelectedSEMethod = jest.fn();
+    const mockSetStartYear = jest.fn();
+    const mockSetEndYear = jest.fn();
+    const mockSetSortPreference = jest.fn();
+
+    // Render component
+    const { getByText } = render(
+      <SearchSort
+        searchTerm=""
+        setSearchTerm={mockSetSearchTerm}
+        allSEMethods={["Method 1", "Method 2", "A Specific SE Method"]}
+        selectedSEMethod="Method 1"
+        setSelectedSEMethod={mockSetSelectedSEMethod}
+        startYear={null}
+        setStartYear={mockSetStartYear}
+        endYear={null}
+        setEndYear={mockSetEndYear}
+        sortPreference={null}
+        setSortPreference={mockSetSortPreference}
+      />
+    );
+
+    // Interact with the dropdown
+    const dropdown = getByText("Method 1").closest("select");
+    if (dropdown) {
+      fireEvent.change(dropdown, { target: { value: "A Specific SE Method" } });
+    }
+
+    // Assert
+    expect(mockSetSelectedSEMethod).toHaveBeenCalledWith(
+      "A Specific SE Method"
+    );
+
+    // Interact with the "Most Recent" button
+    fireEvent.click(getByText("Most Recent"));
+
+    // Assert
+    expect(mockSetSortPreference).toHaveBeenCalledWith(expect.any(Function));
+
+    const passedFunctionForMostRecent = mockSetSortPreference.mock.calls[0][0];
+    expect(passedFunctionForMostRecent("mostRecent")).toBe(null);
+    expect(passedFunctionForMostRecent(null)).toBe("mostRecent");
+  });
+});

--- a/__tests__/UserView.test.tsx
+++ b/__tests__/UserView.test.tsx
@@ -4,6 +4,7 @@ import { render, waitFor, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import UserView from "../components/UserView";
+import SearchSort from "../components/SearchSort";
 
 describe("UserView Component", () => {
   // Add some mock articles to test the display of data
@@ -54,6 +55,18 @@ describe("UserView Component", () => {
       pages: "5",
     },
   ];
+
+  it("renders without crashing", () => {
+    render(<UserView articles={mockArticles} />);
+  });
+
+  it("filters articles based on SE method", () => {
+    const { getByText, queryByText } = render(
+      <UserView articles={mockArticles} />
+    );
+    fireEvent.click(getByText("Method 1")); // Mocked SE method
+    expect(queryByText("Method 1")).toBeTruthy();
+  });
 
   test("renders UserView component", () => {
     render(<UserView articles={mockArticles} />);
@@ -121,7 +134,7 @@ describe("UserView Component", () => {
   test("clears the search term and displays original articles", async () => {
     render(<UserView articles={mockArticles} />);
 
-    // Find the Bootstrap input field and type in it
+    // Find the input field and type in it
     const searchInput = screen.getByRole("textbox");
     userEvent.type(searchInput, "Test Title 2");
 
@@ -140,7 +153,7 @@ describe("UserView Component", () => {
   test("notifies when no matching articles are found", async () => {
     render(<UserView articles={mockArticles} />);
 
-    // Find the Bootstrap input field and type a non-existent term
+    // Find the input field and type a non-existent term
     const searchInput = screen.getByRole("textbox");
     userEvent.type(searchInput, "Non-existent Term");
 

--- a/components/ModeratorView.tsx
+++ b/components/ModeratorView.tsx
@@ -176,7 +176,7 @@ function ModeratorView({ articles }: Props) {
         </div>
         {noResults ? (
           <p className={styles["error-message"]}>
-            No articles found for "{searchTerm}"
+            No articles found for selection.
           </p>
         ) : (
           <table {...getTableProps()} className={styles.table}>

--- a/components/SearchSort.tsx
+++ b/components/SearchSort.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import styles from "./styling/SearchSort.module.css";
+
+type Props = {
+  searchTerm: string;
+  setSearchTerm: React.Dispatch<React.SetStateAction<string>>;
+  allSEMethods: string[];
+  selectedSEMethod: string;
+  setSelectedSEMethod: React.Dispatch<React.SetStateAction<string>>;
+  startYear: number | null;
+  setStartYear: React.Dispatch<React.SetStateAction<number | null>>;
+  endYear: number | null;
+  setEndYear: React.Dispatch<React.SetStateAction<number | null>>;
+  sortPreference: "mostRecent" | "mostReputable" | null;
+  setSortPreference: React.Dispatch<
+    React.SetStateAction<"mostRecent" | "mostReputable" | null>
+  >;
+};
+
+const SearchSort: React.FC<Props> = ({
+  searchTerm,
+  setSearchTerm,
+  allSEMethods,
+  selectedSEMethod,
+  setSelectedSEMethod,
+  startYear,
+  setStartYear,
+  endYear,
+  setEndYear,
+  sortPreference,
+  setSortPreference,
+}) => {
+  return (
+    <div className={styles.searchAndSelectorContainer}>
+      {/* Dropdown */}
+      <div className={styles.dropdownContainer}>
+        <span>Sort by: </span>
+        <select
+          value={selectedSEMethod}
+          onChange={(e) => setSelectedSEMethod(e.target.value)}
+          className={`form-control ${styles.seMethodSelector}`}
+        >
+          <option>All SE Methods</option>
+          {allSEMethods.map((method) => (
+            <option key={method}>{method}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Year Selector */}
+      <div className={styles.yearSelectorContainer}>
+        <input
+          type="number"
+          placeholder="From Year"
+          value={startYear || ""}
+          onChange={(e) => setStartYear(Number(e.target.value))}
+          className={`form-control ml-2 ${styles.yearInput}`}
+        />
+        <p>_</p>
+        <input
+          type="number"
+          placeholder="To Year"
+          value={endYear || ""}
+          onChange={(e) => setEndYear(Number(e.target.value))}
+          className={`form-control ml-2 ${styles.yearInput}`}
+        />
+      </div>
+
+      {/* Toggle Buttons */}
+      <div className={styles.toggleButtonContainer}>
+        <button
+          onClick={() =>
+            setSortPreference((prev) =>
+              prev === "mostRecent" ? null : "mostRecent"
+            )
+          }
+          className={`btn ${
+            sortPreference === "mostRecent"
+              ? "btn-secondary"
+              : "btn-outline-secondary"
+          }`}
+        >
+          Most Recent
+        </button>
+        <button
+          onClick={() =>
+            setSortPreference((prev) =>
+              prev === "mostReputable" ? null : "mostReputable"
+            )
+          }
+          className={`btn ${
+            sortPreference === "mostReputable"
+              ? "btn-secondary"
+              : "btn-outline-secondary"
+          }`}
+        >
+          Most Reputable
+        </button>
+      </div>
+      {/* Search Bar */}
+      <div className={styles["search-bar"]}>
+        <input
+          type="text"
+          placeholder="Search articles"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="form-control"
+        />
+        <button
+          onClick={() => setSearchTerm("")}
+          disabled={!searchTerm}
+          className="btn btn-primary ml-2"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SearchSort;

--- a/components/UserView.tsx
+++ b/components/UserView.tsx
@@ -79,6 +79,10 @@ function UserView({ articles }: Props) {
   const [startYear, setStartYear] = useState<number | null>(null);
   const [endYear, setEndYear] = useState<number | null>(null);
 
+  const [sortPreference, setSortPreference] = useState<
+    "mostRecent" | "mostReputable" | null
+  >(null);
+
   const allSEMethods = Array.from(
     new Set(articles.flatMap((article: Article) => article.SE_methods))
   );
@@ -199,9 +203,34 @@ function UserView({ articles }: Props) {
     setExpandedRow(expandedRow === id ? null : id);
   };
 
+  const sortedArticles = filteredArticles.sort((a, b) => {
+    if (sortPreference === "mostRecent") {
+      return (
+        new Date(b.date_published).getTime() -
+        new Date(a.date_published).getTime()
+      );
+    } else if (sortPreference === "mostReputable") {
+      const order = [
+        "Strongly agree",
+        "Agree",
+        "Somewhat agree",
+        "Somewhat disagree",
+        "Disagree",
+        "Strongly disagree",
+      ];
+      return order.indexOf(a.result) - order.indexOf(b.result);
+    } else {
+      // Define the default sort logic when neither button is pressed (e.g., by date).
+      return (
+        new Date(b.date_published).getTime() -
+        new Date(a.date_published).getTime()
+      );
+    }
+  });
+
   // Initialize the table with columns and data
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
-    useTable({ columns: columns as Column<Article>[], data: filteredArticles });
+    useTable({ columns: columns as Column<Article>[], data: sortedArticles });
 
   return (
     <div className={styles.container}>
@@ -253,6 +282,36 @@ function UserView({ articles }: Props) {
             />
           </div>
         </div>
+      </div>
+      <div className={styles.toggleButtonContainer}>
+        <button
+          onClick={() =>
+            setSortPreference((prev) =>
+              prev === "mostRecent" ? null : "mostRecent"
+            )
+          }
+          className={`btn ${
+            sortPreference === "mostRecent"
+              ? "btn-secondary"
+              : "btn-outline-secondary"
+          }`}
+        >
+          Most Recent
+        </button>
+        <button
+          onClick={() =>
+            setSortPreference((prev) =>
+              prev === "mostReputable" ? null : "mostReputable"
+            )
+          }
+          className={`btn ${
+            sortPreference === "mostReputable"
+              ? "btn-secondary"
+              : "btn-outline-secondary"
+          }`}
+        >
+          Most Reputable
+        </button>
       </div>
       {noResults ? (
         <p className={styles["error-message"]}>

--- a/components/UserView.tsx
+++ b/components/UserView.tsx
@@ -176,7 +176,7 @@ function UserView({ articles }: Props) {
           ),
         },
         {
-          Header: "Result",
+          Header: "Strength of Claims",
           accessor: "result",
           Cell: ({ cell: { value } }) => (
             <div>{highlightSearchTerm(value, searchTerm)}</div>
@@ -188,14 +188,6 @@ function UserView({ articles }: Props) {
           Cell: ({ cell: { value } }) => {
             const methodsStr = (value || []).join(", ");
             return <div>{highlightSearchTerm(methodsStr, searchTerm)}</div>;
-          },
-        },
-        {
-          Header: "Number of Claims",
-          accessor: "claims",
-          Cell: ({ cell: { value } }) => {
-            const claimsCount = value ? String(value.length) : "0";
-            return <div>{highlightSearchTerm(claimsCount, searchTerm)}</div>;
           },
         },
       ] as Column<Article>[],
@@ -312,13 +304,13 @@ function UserView({ articles }: Props) {
                       <td colSpan={9} className={styles.expandedCell}>
                         {" "}
                         <ul>
-                          <h4>Claims:</h4>
+                          <h5 className={styles.spacing}>Claims:</h5>
                           {row.original.claims.map((claim, index) => (
                             <li key={index}>{claim}</li>
                           ))}
-                          <h4>Description:</h4>
-                          <p>{row.original.description}</p>
-                          <h4>Evidence Result:</h4>
+                          <h5 className={styles.spacing}>
+                            Analyst Review Result:
+                          </h5>
                           <p>{row.original.result}</p>
                         </ul>
                       </td>

--- a/components/UserView.tsx
+++ b/components/UserView.tsx
@@ -76,10 +76,12 @@ function UserView({ articles }: Props) {
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedSEMethod, setSelectedSEMethod] = useState("All SE Methods");
 
+  const [startYear, setStartYear] = useState<number | null>(null);
+  const [endYear, setEndYear] = useState<number | null>(null);
+
   const allSEMethods = Array.from(
     new Set(articles.flatMap((article: Article) => article.SE_methods))
   );
-
   const filteredArticles = articles.filter((article) => {
     if (
       selectedSEMethod !== "All SE Methods" &&
@@ -87,8 +89,20 @@ function UserView({ articles }: Props) {
     ) {
       return false;
     }
+
+    const publicationYear = new Date(article.date_published).getFullYear();
+
+    if (startYear && publicationYear < startYear) {
+      return false;
+    }
+
+    if (endYear && publicationYear > endYear) {
+      return false;
+    }
+
     // Create an array of all values from each column
     const allColumnValues = Object.values(article).join(" ").toLowerCase();
+
     // Check if any part of the article contains the search term
     return allColumnValues.includes(searchTerm.toLowerCase());
   });
@@ -217,9 +231,8 @@ function UserView({ articles }: Props) {
             Clear
           </button>
         </div>
-
         <div className={styles.instructionLine}>
-          <span>Sort by a software engineering method: </span>
+          <span>Sort by: </span>
           <select
             value={selectedSEMethod}
             onChange={(e) => setSelectedSEMethod(e.target.value)}
@@ -230,12 +243,28 @@ function UserView({ articles }: Props) {
               <option key={method}>{method}</option>
             ))}
           </select>
+          <div className={styles.yearSelectorContainer}>
+            <input
+              type="number"
+              placeholder="From Year"
+              value={startYear || ""}
+              onChange={(e) => setStartYear(Number(e.target.value))}
+              className={`form-control ml-2 ${styles.yearInput}`}
+            />
+            <p>_</p>
+            <input
+              type="number"
+              placeholder="To Year"
+              value={endYear || ""}
+              onChange={(e) => setEndYear(Number(e.target.value))}
+              className={`form-control ml-2 ${styles.yearInput}`}
+            />
+          </div>
         </div>
       </div>
-
       {noResults ? (
         <p className={styles["error-message"]}>
-          No articles found for "{searchTerm}"
+          No articles found for selection.
         </p>
       ) : (
         <table {...getTableProps()} className={styles.table}>

--- a/components/UserView.tsx
+++ b/components/UserView.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { useTable, Column } from "react-table";
 import styles from "./styling/UserView.module.css";
 import "bootstrap/dist/css/bootstrap.css";
+import SearchSort from "./SearchSort";
 
 // Represents article data
 type Article = {
@@ -235,84 +236,19 @@ function UserView({ articles }: Props) {
   return (
     <div className={styles.container}>
       <WelcomeMessage />
-      <div className={styles.searchAndSelectorContainer}>
-        <div className={styles["search-bar"]}>
-          <input
-            type="text"
-            placeholder="Search articles"
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="form-control"
-          />
-          <button
-            onClick={() => setSearchTerm("")}
-            disabled={!searchTerm}
-            className="btn btn-primary ml-2"
-          >
-            Clear
-          </button>
-        </div>
-        <div className={styles.instructionLine}>
-          <span>Sort by: </span>
-          <select
-            value={selectedSEMethod}
-            onChange={(e) => setSelectedSEMethod(e.target.value)}
-            className={`form-control ${styles.seMethodSelector}`}
-          >
-            <option>All SE Methods</option>
-            {allSEMethods.map((method) => (
-              <option key={method}>{method}</option>
-            ))}
-          </select>
-          <div className={styles.yearSelectorContainer}>
-            <input
-              type="number"
-              placeholder="From Year"
-              value={startYear || ""}
-              onChange={(e) => setStartYear(Number(e.target.value))}
-              className={`form-control ml-2 ${styles.yearInput}`}
-            />
-            <p>_</p>
-            <input
-              type="number"
-              placeholder="To Year"
-              value={endYear || ""}
-              onChange={(e) => setEndYear(Number(e.target.value))}
-              className={`form-control ml-2 ${styles.yearInput}`}
-            />
-          </div>
-        </div>
-      </div>
-      <div className={styles.toggleButtonContainer}>
-        <button
-          onClick={() =>
-            setSortPreference((prev) =>
-              prev === "mostRecent" ? null : "mostRecent"
-            )
-          }
-          className={`btn ${
-            sortPreference === "mostRecent"
-              ? "btn-secondary"
-              : "btn-outline-secondary"
-          }`}
-        >
-          Most Recent
-        </button>
-        <button
-          onClick={() =>
-            setSortPreference((prev) =>
-              prev === "mostReputable" ? null : "mostReputable"
-            )
-          }
-          className={`btn ${
-            sortPreference === "mostReputable"
-              ? "btn-secondary"
-              : "btn-outline-secondary"
-          }`}
-        >
-          Most Reputable
-        </button>
-      </div>
+      <SearchSort
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+        allSEMethods={allSEMethods}
+        selectedSEMethod={selectedSEMethod}
+        setSelectedSEMethod={setSelectedSEMethod}
+        startYear={startYear}
+        setStartYear={setStartYear}
+        endYear={endYear}
+        setEndYear={setEndYear}
+        sortPreference={sortPreference}
+        setSortPreference={setSortPreference}
+      />
       {noResults ? (
         <p className={styles["error-message"]}>
           No articles found for selection.

--- a/components/UserView.tsx
+++ b/components/UserView.tsx
@@ -74,8 +74,19 @@ function WelcomeMessage() {
 
 function UserView({ articles }: Props) {
   const [searchTerm, setSearchTerm] = useState("");
+  const [selectedSEMethod, setSelectedSEMethod] = useState("All SE Methods");
+
+  const allSEMethods = Array.from(
+    new Set(articles.flatMap((article: Article) => article.SE_methods))
+  );
 
   const filteredArticles = articles.filter((article) => {
+    if (
+      selectedSEMethod !== "All SE Methods" &&
+      !article.SE_methods.includes(selectedSEMethod)
+    ) {
+      return false;
+    }
     // Create an array of all values from each column
     const allColumnValues = Object.values(article).join(" ").toLowerCase();
     // Check if any part of the article contains the search term
@@ -189,7 +200,7 @@ function UserView({ articles }: Props) {
   return (
     <div className={styles.container}>
       <WelcomeMessage />
-      <div className={styles.fixedWidthContainer}>
+      <div className={styles.searchAndSelectorContainer}>
         <div className={styles["search-bar"]}>
           <input
             type="text"
@@ -206,78 +217,90 @@ function UserView({ articles }: Props) {
             Clear
           </button>
         </div>
-        {noResults ? (
-          <p className={styles["error-message"]}>
-            No articles found for "{searchTerm}"
-          </p>
-        ) : (
-          <table {...getTableProps()} className={styles.table}>
-            <thead>
-              {headerGroups.map((headerGroup) => (
-                <tr
-                  {...headerGroup.getHeaderGroupProps()}
-                  className={styles.headerRow}
-                >
-                  {headerGroup.headers.map((column) => (
-                    <th {...column.getHeaderProps()} className={styles.header}>
-                      {column.render("Header")}
-                    </th>
-                  ))}
-                </tr>
-              ))}
-            </thead>
-            <tbody {...getTableBodyProps()}>
-              {rows.map((row) => {
-                prepareRow(row);
-                return (
-                  <React.Fragment key={row.id}>
-                    <tr {...row.getRowProps()} className={styles.row}>
-                      {row.cells.map((cell) => (
-                        <td
-                          {...cell.getCellProps()}
-                          className={styles.tableData}
-                        >
-                          {cell.render("Cell")}
-                        </td>
-                      ))}
-                      <td className={styles.tableData}>
-                        <button
-                          className={`btn ${
-                            expandedRow === row.id
-                              ? "btn-outline-secondary"
-                              : "btn-outline-secondary"
-                          }`}
-                          onClick={() => toggleRow(row.id)}
-                        >
-                          {expandedRow === row.id ? "Show less" : "Show more"}
-                        </button>
+
+        <div className={styles.instructionLine}>
+          <span>Sort by a software engineering method: </span>
+          <select
+            value={selectedSEMethod}
+            onChange={(e) => setSelectedSEMethod(e.target.value)}
+            className={`form-control ${styles.seMethodSelector}`}
+          >
+            <option>All SE Methods</option>
+            {allSEMethods.map((method) => (
+              <option key={method}>{method}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {noResults ? (
+        <p className={styles["error-message"]}>
+          No articles found for "{searchTerm}"
+        </p>
+      ) : (
+        <table {...getTableProps()} className={styles.table}>
+          <thead>
+            {headerGroups.map((headerGroup) => (
+              <tr
+                {...headerGroup.getHeaderGroupProps()}
+                className={styles.headerRow}
+              >
+                {headerGroup.headers.map((column) => (
+                  <th {...column.getHeaderProps()} className={styles.header}>
+                    {column.render("Header")}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody {...getTableBodyProps()}>
+            {rows.map((row) => {
+              prepareRow(row);
+              return (
+                <React.Fragment key={row.id}>
+                  <tr {...row.getRowProps()} className={styles.row}>
+                    {row.cells.map((cell) => (
+                      <td {...cell.getCellProps()} className={styles.tableData}>
+                        {cell.render("Cell")}
+                      </td>
+                    ))}
+                    <td className={styles.tableData}>
+                      <button
+                        className={`btn ${
+                          expandedRow === row.id
+                            ? "btn-outline-secondary"
+                            : "btn-outline-secondary"
+                        }`}
+                        onClick={() => toggleRow(row.id)}
+                      >
+                        {expandedRow === row.id ? "Show less" : "Show more"}
+                      </button>
+                    </td>
+                  </tr>
+                  {/* Display additional information for expanded row */}
+                  {expandedRow === row.id && (
+                    <tr className={styles.expandedRow}>
+                      <td colSpan={9} className={styles.expandedCell}>
+                        {" "}
+                        <ul>
+                          <h4>Claims:</h4>
+                          {row.original.claims.map((claim, index) => (
+                            <li key={index}>{claim}</li>
+                          ))}
+                          <h4>Description:</h4>
+                          <p>{row.original.description}</p>
+                          <h4>Evidence Result:</h4>
+                          <p>{row.original.result}</p>
+                        </ul>
                       </td>
                     </tr>
-                    {/* Display additional information for expanded row */}
-                    {expandedRow === row.id && (
-                      <tr className={styles.expandedRow}>
-                        <td colSpan={9} className={styles.expandedCell}>
-                          {" "}
-                          <ul>
-                            <h4>Claims:</h4>
-                            {row.original.claims.map((claim, index) => (
-                              <li key={index}>{claim}</li>
-                            ))}
-                            <h4>Description:</h4>
-                            <p>{row.original.description}</p>
-                            <h4>Evidence Result:</h4>
-                            <p>{row.original.result}</p>
-                          </ul>
-                        </td>
-                      </tr>
-                    )}
-                  </React.Fragment>
-                );
-              })}
-            </tbody>
-          </table>
-        )}
-      </div>
+                  )}
+                </React.Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/components/styling/SearchSort.module.css
+++ b/components/styling/SearchSort.module.css
@@ -1,0 +1,41 @@
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.searchBar {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex: 1;
+  width: 150px;
+}
+
+.seMethodSelector {
+  width: 200px;
+}
+
+.yearInput {
+  width: 130px;
+}
+
+.searchAndSelectorContainer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+}
+
+.search-bar,
+.dropdownContainer,
+.yearSelectorContainer,
+.toggleButtonContainer {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 10px;
+}

--- a/components/styling/UserView.module.css
+++ b/components/styling/UserView.module.css
@@ -97,3 +97,25 @@
   justify-content: flex-start;
   gap: 20px;
 }
+
+.instructionLine {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.seMethodSelector {
+  margin-right: 10px;
+  margin-left: 10px;
+  width: 240px;
+  display: inline-block;
+}
+
+.yearSelectorContainer {
+  display: flex;
+  gap: 10px; /* space between the year input boxes */
+}
+
+.form-control {
+  width: 120px; /* Adjust the width of the year input boxes */
+}

--- a/components/styling/UserView.module.css
+++ b/components/styling/UserView.module.css
@@ -117,5 +117,9 @@
 }
 
 .form-control {
-  width: 120px; /* Adjust the width of the year input boxes */
+  width: 120px;
+}
+
+.spacing {
+  margin-top: 20px;
 }

--- a/components/styling/UserView.module.css
+++ b/components/styling/UserView.module.css
@@ -85,3 +85,15 @@
   text-align: "left";
   padding-left: 10px;
 }
+
+.seMethodSelector {
+  width: 250px;
+  display: inline-block; /* to make sure it doesn't take the full width of its parent */
+}
+
+.searchAndSelectorContainer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 20px;
+}

--- a/components/styling/UserView.module.css
+++ b/components/styling/UserView.module.css
@@ -87,7 +87,7 @@
 }
 
 .seMethodSelector {
-  width: 250px;
+  width: 150px;
   display: inline-block; /* to make sure it doesn't take the full width of its parent */
 }
 
@@ -107,7 +107,7 @@
 .seMethodSelector {
   margin-right: 10px;
   margin-left: 10px;
-  width: 240px;
+  width: 170px;
   display: inline-block;
 }
 
@@ -115,11 +115,21 @@
   display: flex;
   gap: 10px; /* space between the year input boxes */
 }
-
 .form-control {
-  width: 120px;
+  width: 100px;
 }
-
 .spacing {
   margin-top: 20px;
+}
+
+.toggle-button {
+  border: 1px solid #ddd;
+  background-color: #f8f9fa;
+  transition: background-color 0.3s, box-shadow 0.3s;
+}
+
+.toggle-button.active {
+  background-color: #007bff;
+  color: white;
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }

--- a/components/styling/UserView.module.css
+++ b/components/styling/UserView.module.css
@@ -20,9 +20,15 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: 450px;
+  width: 450px !important;
   margin-bottom: 16px;
   margin-top: 16px;
+  flex-grow: 2;
+  width: auto !important;
+}
+.search-bar .form-control {
+  flex-grow: 2;
+  min-width: 150px;
 }
 
 /* Styling for error messages */
@@ -86,16 +92,12 @@
   padding-left: 10px;
 }
 
-.seMethodSelector {
-  width: 150px;
-  display: inline-block; /* to make sure it doesn't take the full width of its parent */
-}
-
 .searchAndSelectorContainer {
   display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 20px;
+  align-items: center; /* if you want vertically centered items */
+  justify-content: space-between; /* space out main blocks */
+  gap: 20px !important;
+  margin-right: 10px;
 }
 
 .instructionLine {
@@ -107,16 +109,22 @@
 .seMethodSelector {
   margin-right: 10px;
   margin-left: 10px;
-  width: 170px;
+  width: 160px !important;
   display: inline-block;
+  flex-basis: 130px;
+  flex-shrink: 0; /* don't want this to shrink */
+  gap: 20px !important;
 }
 
 .yearSelectorContainer {
   display: flex;
   gap: 10px; /* space between the year input boxes */
+  width: auto;
+  align-items: center;
 }
+
 .form-control {
-  width: 100px;
+  width: auto !important;
 }
 .spacing {
   margin-top: 20px;
@@ -132,4 +140,15 @@
   background-color: #007bff;
   color: white;
   box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+}
+
+.sortButtonsContainer {
+  display: flex;
+  gap: 10px;
+}
+
+.yearInput {
+  flex-basis: 80px;
+  flex-shrink: 1;
+  width: 140px !important;
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -134,6 +134,7 @@ export default function Home({
           background-color: #263871;
           padding: 1rem 2rem;
           width: 100%;
+          padding-right: 40px;
         }
 
         .logo {
@@ -193,6 +194,8 @@ export default function Home({
           justify-content: flex-start;
           align-items: flex-start;
           width: 100%;
+          padding-right: 10px;
+          padding-left: 10px;
         }
 
         header nav ul {


### PR DESCRIPTION
Hello! This pull request includes the following features:

- Practitioners are now able to sort the table by the SE methods, which is set to 'All SE methods' by default. This means anytime that a new SE method is added into SPEED from an article, practitioners will be able to sort all articles by it.
- Articles can now be sorted by year (from year - to year)
- 'Number of claims' column was changed to 'Strength of Claims'
- Two toggle buttons were added, to order the table by either most recent or most reputable (highest strength of claims)
- Unit testing was implemented to test the new features :)

#### Thanks for your review!